### PR TITLE
WIP! Use MOJO logging instead of sysout and some docs

### DIFF
--- a/jabel-javac-plugin/build.gradle
+++ b/jabel-javac-plugin/build.gradle
@@ -8,4 +8,5 @@ sourceCompatibility = targetCompatibility = 8
 dependencies {
     compile 'net.bytebuddy:byte-buddy:1.10.8'
     compile 'net.bytebuddy:byte-buddy-agent:1.10.8'
+    compile 'org.apache.maven:maven-plugin-api:3.0'
 }

--- a/jabel-javac-plugin/src/main/java/com/github/bsideup/jabel/JabelJavacProcessor.java
+++ b/jabel-javac-plugin/src/main/java/com/github/bsideup/jabel/JabelJavacProcessor.java
@@ -7,6 +7,7 @@ import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.agent.ByteBuddyAgent;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.dynamic.loading.ClassReloadingStrategy;
+import org.apache.maven.plugin.logging.SystemStreamLog;
 
 import javax.annotation.processing.Completion;
 import javax.annotation.processing.ProcessingEnvironment;
@@ -29,7 +30,11 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 public class JabelJavacProcessor implements Processor {
+    private static org.apache.maven.plugin.logging.Log log = new SystemStreamLog();
 
+    /**
+     * Set of the all the features we want to force enable in our 8 target
+     */
     private static final Set<Source.Feature> ENABLED_FEATURES = Stream
             .of(
                     "PRIVATE_SAFE_VARARGS",
@@ -61,10 +66,17 @@ public class JabelJavacProcessor implements Processor {
             .collect(Collectors.toSet());
 
     static {
-        ByteBuddyAgent.install();
+        log.info("Jabel static initialising ByteBuddy");
 
+        ByteBuddyAgent.install();
         ByteBuddy byteBuddy = new ByteBuddy();
 
+        /**
+         * Inject our code into the JDK version checks
+         *
+         * @see JavacParser#checkSourceLevel
+         * @see JavaTokenizer#checkSourceLevel
+         */
         for (Class<?> clazz : Arrays.asList(JavacParser.class, JavaTokenizer.class)) {
             byteBuddy
                     .redefine(clazz)
@@ -76,12 +88,18 @@ public class JabelJavacProcessor implements Processor {
                     .load(clazz.getClassLoader(), ClassReloadingStrategy.fromInstalledAgent());
         }
 
+        /**
+         * For all the features in {@link #ENABLED_FEATURES}, override the min JDK level, reducing it to 8
+         *
+         * @see ENABLED_FEATURES
+          */
         try {
             Field field = Source.Feature.class.getDeclaredField("minLevel");
             field.setAccessible(true);
 
             for (Source.Feature feature : ENABLED_FEATURES) {
                 field.set(feature, Source.JDK8);
+                // sanity check our code
                 if (!feature.allowedInSource(Source.JDK8)) {
                     throw new IllegalStateException(feature.name() + " minLevel instrumentation failed!");
                 }
@@ -89,6 +107,7 @@ public class JabelJavacProcessor implements Processor {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+        log.info("Jabel ByteBuddy initialisation complete");
     }
 
     @Override
@@ -98,7 +117,7 @@ public class JabelJavacProcessor implements Processor {
 
     @Override
     public void init(ProcessingEnvironment processingEnv) {
-        System.out.println(
+        log.debug(
                 ENABLED_FEATURES.stream()
                         .map(Enum::name)
                         .collect(Collectors.joining(


### PR DESCRIPTION
Attempts to address #8 

Implementation as is prints out DEBUG level also, and doesn't appear to routing through the proper logging system as the actual output appears differently to other maven logging statements - 

```
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 26 source files to /Users/antony/repos/confluent/async-consumer/async-consumer-core/target/test-classes
[info] Jabel static initialising ByteBuddy
[info] Jabel ByteBuddy initialisation complete
[debug] Jabel: initialized. Enabled features:
	- LOCAL_VARIABLE_TYPE_INFERENCE
	- DIAMOND_WITH_ANONYMOUS_CLASS_CREATION
	- SWITCH_RULE
	- EFFECTIVELY_FINAL_VARIABLES_IN_TRY_WITH_RESOURCES
	- PRIVATE_SAFE_VARARGS
	- VAR_SYNTAX_IMPLICIT_LAMBDAS
	- TEXT_BLOCKS
	- SWITCH_EXPRESSION
	- SWITCH_MULTIPLE_CASE_LABELS

[INFO] ...
```

Implementation info from: https://stackoverflow.com/a/22423213/105741

Tried using Slf4j also, and got an unimplemented slf4j subsystem response, so doesn't seem like that's being used...