### PR TITLE
Install bytebuddy agent once per JVM

### DIFF
--- a/jabel-javac-plugin/build.gradle
+++ b/jabel-javac-plugin/build.gradle
@@ -8,6 +8,7 @@ sourceCompatibility = targetCompatibility = 8
 dependencies {
     implementation 'net.bytebuddy:byte-buddy:1.11.1'
     implementation 'net.bytebuddy:byte-buddy-agent:1.11.1'
+    implementation 'net.java.dev.jna:jna:5.8.0'
 }
 
 

--- a/jabel-javac-plugin/build.gradle
+++ b/jabel-javac-plugin/build.gradle
@@ -8,7 +8,6 @@ sourceCompatibility = targetCompatibility = 8
 dependencies {
     implementation 'net.bytebuddy:byte-buddy:1.11.1'
     implementation 'net.bytebuddy:byte-buddy-agent:1.11.1'
-    implementation 'net.java.dev.jna:jna:5.8.0'
 }
 
 

--- a/jabel-javac-plugin/src/main/java/com/github/bsideup/jabel/JabelCompilerPlugin.java
+++ b/jabel-javac-plugin/src/main/java/com/github/bsideup/jabel/JabelCompilerPlugin.java
@@ -20,15 +20,12 @@ import net.bytebuddy.implementation.bytecode.constant.IntegerConstant;
 import net.bytebuddy.pool.TypePool;
 import net.bytebuddy.utility.JavaModule;
 
-import java.lang.instrument.Instrumentation;
 import java.util.*;
 
 import static net.bytebuddy.matcher.ElementMatchers.*;
 
 public class JabelCompilerPlugin implements Plugin {
-
-    @Override
-    public void init(JavacTask task, String... args) {
+    static {
         Map<String, AsmVisitorWrapper> visitors = new HashMap<String, AsmVisitorWrapper>() {{
             // Disable the preview feature check
             AsmVisitorWrapper checkSourceLevelAdvice = Advice.to(CheckSourceLevelAdvice.class)
@@ -118,7 +115,10 @@ public class JabelCompilerPlugin implements Plugin {
                 Collections.emptySet(),
                 Collections.emptyMap()
         );
+    }
 
+    @Override
+    public void init(JavacTask task, String... args) {
         Context context = ((JavacTaskImpl) task).getContext();
         JavacMessages.instance(context).add(locale -> new ResourceBundle() {
             @Override


### PR DESCRIPTION
Move byte buddy agent installation to a static block so
that the installation only happens once per JVM.

This ensures that the plugin works well with BUCK(and likewise) build
systems where multiple javac compilation tasks are started parallelly in
the same JVM. Without this, the JVM crashes nondeterministically.

This will also work well in the Gradle build system where one javac
task runs per JVM.

Also remove the unused `net.java.dev.jna:jna:5.8.0` dependency.