### PR TITLE
Change call to JavacTaskImpl.getContext() to use superclass

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,8 @@
 subprojects {
     apply from: "$rootDir/gradle/publishing.gradle"
 
-    group = 'com.github.bsideup.jabel'
+    group = 'com.metsci.ext.com.github.bsideup.jabel'
+    version = '0.4.3'
     repositories {
         jcenter()
     }

--- a/jabel-javac-plugin/build.gradle
+++ b/jabel-javac-plugin/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "java"
     id "maven-publish"
+    id 'com.github.johnrengelman.shadow' version '7.1.2'
 }
 
 sourceCompatibility = targetCompatibility = 8
@@ -34,4 +35,10 @@ publishing {
             artifact javadocJar
         }
     }
+}
+
+shadowJar {
+    include '*.jar'
+    exclude 'net.java*'
+    relocate 'net.bytebuddy', 'shadow.net.bytebuddy'
 }

--- a/jabel-javac-plugin/pom.xml
+++ b/jabel-javac-plugin/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.metsci.ext.com.github.bsideup.jabel</groupId>
     <artifactId>jabel-javac-plugin</artifactId>
-    <version>0.4.4-SNAPSHOT</version>
+    <version>0.4.4</version>
     <packaging>jar</packaging>
 
     <name>Subnode Core</name>

--- a/jabel-javac-plugin/pom.xml
+++ b/jabel-javac-plugin/pom.xml
@@ -49,6 +49,39 @@
                     </compilerArgs>
                 </configuration>
             </plugin>
+
+            <!-- Shade Glimpse so we don't conflict with TRK's Glimpse -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <configuration>
+                    <relocations combine.children="append">
+                        <relocation>
+                            <pattern>net.bytebuddy</pattern>
+                            <shadedPattern>
+                                jabel.shaded.net.bytebuddy
+                            </shadedPattern>
+                            <includes>
+                                <include>net.bytebuddy.**</include>
+                            </includes>
+                        </relocation>
+                    </relocations>
+                    <artifactSet>
+                        <includes>
+                            <include>net.bytebuddy:*</include>
+                        </includes>
+                    </artifactSet>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/jabel-javac-plugin/pom.xml
+++ b/jabel-javac-plugin/pom.xml
@@ -1,0 +1,57 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.metsci.ext.com.github.bsideup.jabel</groupId>
+    <artifactId>jabel-javac-plugin</artifactId>
+    <version>0.4.4-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Subnode Core</name>
+    <description>Core algorithms to generate Farthest-on-Region geometries</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.11.21</version>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-agent</artifactId>
+            <version>1.11.21</version>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>5.9.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.olivergondza</groupId>
+            <artifactId>maven-jdk-tools-wrapper</artifactId>
+            <version>0.1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                    <compilerArgs>
+                        <compilerArg>--add-exports</compilerArg><compilerArg>jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</compilerArg>
+                        <compilerArg>--add-exports</compilerArg><compilerArg>jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</compilerArg>
+                        <compilerArg>--add-exports</compilerArg><compilerArg>jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</compilerArg>
+                        <compilerArg>--add-exports</compilerArg><compilerArg>jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</compilerArg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+
+</project>

--- a/jabel-javac-plugin/src/main/java/com/github/bsideup/jabel/JabelCompilerPlugin.java
+++ b/jabel-javac-plugin/src/main/java/com/github/bsideup/jabel/JabelCompilerPlugin.java
@@ -2,7 +2,7 @@ package com.github.bsideup.jabel;
 
 import com.sun.source.util.JavacTask;
 import com.sun.source.util.Plugin;
-import com.sun.tools.javac.api.JavacTaskImpl;
+import com.sun.tools.javac.api.BasicJavacTask;
 import com.sun.tools.javac.code.Source;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.JavacMessages;
@@ -111,7 +111,7 @@ public class JabelCompilerPlugin implements Plugin {
 
     @Override
     public void init(JavacTask task, String... args) {
-        Context context = ((JavacTaskImpl) task).getContext();
+        Context context = ((BasicJavacTask) task).getContext();
         JavacMessages.instance(context).add(locale -> new ResourceBundle() {
             @Override
             protected Object handleGetObject(String key) {


### PR DESCRIPTION
This is an unstable API and on AdoptOpenJDK-16.0.1+9 the class of "task" is `BasicJavacTask`, not `JavacTaskImpl`. Since `BasicJavacTask` is a superclass, this should be a stable change.