### PR TITLE
143: Update ByteBuddy to support Java 19

### DIFF
--- a/jabel-javac-plugin/build.gradle
+++ b/jabel-javac-plugin/build.gradle
@@ -6,8 +6,8 @@ plugins {
 sourceCompatibility = targetCompatibility = 8
 
 dependencies {
-    implementation 'net.bytebuddy:byte-buddy:1.11.21'
-    implementation 'net.bytebuddy:byte-buddy-agent:1.11.21'
+    implementation 'net.bytebuddy:byte-buddy:1.12.10 '
+    implementation 'net.bytebuddy:byte-buddy-agent:1.12.10 '
     implementation 'net.java.dev.jna:jna:5.9.0'
 }
 


### PR DESCRIPTION
[Byte Buddy 1.12.9](https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.12.9)
Add support for Java 19.

Fixes:
- #143

Related:
- #140
- #141 