### PR TITLE
Support JDK 20 and JDK 21

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -7,7 +7,7 @@ configure([tasks.compileJava]) {
     options.release = 8
 
     javaCompiler = javaToolchains.compilerFor {
-        languageVersion = JavaLanguageVersion.of(19)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/jabel-javac-plugin/build.gradle
+++ b/jabel-javac-plugin/build.gradle
@@ -6,7 +6,7 @@ plugins {
 sourceCompatibility = targetCompatibility = 8
 
 dependencies {
-    implementation platform('net.bytebuddy:byte-buddy-parent:1.12.18')
+    implementation platform('net.bytebuddy:byte-buddy-parent:1.14.9')
     implementation 'net.bytebuddy:byte-buddy'
     implementation 'net.bytebuddy:byte-buddy-agent'
     implementation 'net.java.dev.jna:jna:5.12.1'

--- a/jabel-javac-plugin/src/main/java/com/github/bsideup/jabel/JabelCompilerPlugin.java
+++ b/jabel-javac-plugin/src/main/java/com/github/bsideup/jabel/JabelCompilerPlugin.java
@@ -173,8 +173,13 @@ public class JabelCompilerPlugin implements Plugin {
                 @Advice.Argument(value = 1, readOnly = false) Source.Feature feature
         ) {
             if (feature.allowedInSource(Source.JDK8)) {
-                //noinspection UnusedAssignment
-                feature = Source.Feature.LAMBDA;
+                if (Source.MIN.compareTo(Source.JDK8) < 0) {
+                  //noinspection UnusedAssignment
+                  feature = Source.Feature.LAMBDA;
+                } else {
+                  //noinspection UnusedAssignment
+                  feature = Source.Feature.RECORDS;
+                }
             }
         }
     }


### PR DESCRIPTION
This PR aims to resolve the following error when building with JDK 20 (which I hit while working on PicnicSupermarket/error-prone-support#603):
```
Jabel: initialized
An exception has occurred in the compiler (20.0.1). Please file a bug against the Java compiler via the Java bug reporting page (https://bugreport.java.com) after checking the Bug Database (https://bugs.java.com) for duplicates. Include your program, the following diagnostic, and the parameters passed to the Java compiler in your report. Thank you.
java.lang.NoSuchFieldError: LAMBDA
	at jdk.compiler/com.sun.tools.javac.parser.JavacParser.checkSourceLevel(JavacParser.java:5073)
	at jdk.compiler/com.sun.tools.javac.parser.JavacParser.term2Rest(JavacParser.java:1002)
	at jdk.compiler/com.sun.tools.javac.parser.JavacParser.term2(JavacParser.java:957)
	at jdk.compiler/com.sun.tools.javac.parser.JavacParser.term1(JavacParser.java:925)
	at jdk.compiler/com.sun.tools.javac.parser.JavacParser.term(JavacParser.java:881)
	at jdk.compiler/com.sun.tools.javac.parser.JavacParser.term(JavacParser.java:861)
	at jdk.compiler/com.sun.tools.javac.parser.JavacParser.parseExpression(JavacParser.java:758)
	at jdk.compiler/com.sun.tools.javac.parser.JavacParser.parExpression(JavacParser.java:2554)
	at jdk.compiler/com.sun.tools.javac.parser.JavacParser.parseSimpleStatement(JavacParser.java:2808)
	at jdk.compiler/com.sun.tools.javac.parser.JavacParser.blockStatement(JavacParser.java:2656)
	at jdk.compiler/com.sun.tools.javac.parser.JavacParser.blockStatements(JavacParser.java:2593)
	at jdk.compiler/com.sun.tools.javac.parser.JavacParser.block(JavacParser.java:2563)
	at jdk.compiler/com.sun.tools.javac.parser.JavacParser.block(JavacParser.java:2577)
	at jdk.compiler/com.sun.tools.javac.parser.JavacParser.methodDeclaratorRest(JavacParser.java:4628)
	at jdk.compiler/com.sun.tools.javac.parser.JavacParser.classOrInterfaceOrRecordBodyDeclaration(JavacParser.java:4491)
	at jdk.compiler/com.sun.tools.javac.parser.JavacParser.classInterfaceOrRecordBody(JavacParser.java:4375)
	at jdk.compiler/com.sun.tools.javac.parser.JavacParser.classDeclaration(JavacParser.java:4077)
	at jdk.compiler/com.sun.tools.javac.parser.JavacParser.classOrRecordOrInterfaceOrEnumDeclaration(JavacParser.java:4024)
	at jdk.compiler/com.sun.tools.javac.parser.JavacParser.typeDeclaration(JavacParser.java:4013)
	at jdk.compiler/com.sun.tools.javac.parser.JavacParser.parseCompilationUnit(JavacParser.java:3856)
	at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.parse(JavaCompiler.java:634)
	at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.parse(JavaCompiler.java:611)
	at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.parse(JavaCompiler.java:671)
	at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.parseFiles(JavaCompiler.java:1020)
	at jdk.compiler/com.sun.tools.javac.main.JavaCompiler$InitialFileParser.parse(JavaCompiler.java:1940)
	at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.parseFiles(JavaCompiler.java:1007)
	at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:933)
	at jdk.compiler/com.sun.tools.javac.api.JavacTaskImpl.lambda$doCall$0(JavacTaskImpl.java:104)
	at jdk.compiler/com.sun.tools.javac.api.JavacTaskImpl.invocationHelper(JavacTaskImpl.java:152)
	at jdk.compiler/com.sun.tools.javac.api.JavacTaskImpl.doCall(JavacTaskImpl.java:100)
	at jdk.compiler/com.sun.tools.javac.api.JavacTaskImpl.call(JavacTaskImpl.java:94)
	at org.codehaus.plexus.compiler.javac.JavaxToolsCompiler.compileInProcess(JavaxToo
```

This PR also resolves the following error when using JDK 21:
```
Caused by: java.lang.IllegalArgumentException: Java 21 (65) is not supported by the current version of Byte Buddy which officially supports Java 20 (64) - update Byte Buddy or set net.bytebuddy.experimental as a VM property
    at net.bytebuddy.utility.OpenedClassReader.of(OpenedClassReader.java:96)
    at net.bytebuddy.dynamic.scaffold.TypeWriter$Default$ForInlining.create(TypeWriter.java:4011)
    at net.bytebuddy.dynamic.scaffold.TypeWriter$Default.make(TypeWriter.java:2224)
    at net.bytebuddy.dynamic.DynamicType$Builder$AbstractBase$UsingTypeWriter.make(DynamicType.java:4050)
    at net.bytebuddy.dynamic.DynamicType$Builder$AbstractBase.make(DynamicType.java:3734)
    at com.github.bsideup.jabel.JabelCompilerPlugin.lambda$static$0(JabelCompilerPlugin.java:91)
    at java.base/java.util.HashMap.forEach(HashMap.java:1429)
    at com.github.bsideup.jabel.JabelCompilerPlugin.<clinit>(JabelCompilerPlugin.java:84)
    ... 38 more
```

I hope that this change matches the spirit of what `CheckSourceLevelAdvice` is meant to do :crossed_fingers:.

Suggested commit message:
```
Support JDK 20 and JDK 21 (#177)

From JDK 20 onwards the `LAMBDA` feature enum constant is no longer
recognized. Falling back to the `RECORDS` enum constant should guarantee
support for the next few JDK releases.

Upgrading Byte Buddy from 1.12.18 to 1.14.9 introduces Java 21 byte code
support.
```